### PR TITLE
Update concepts-26572ad.md

### DIFF
--- a/docs/20---Concepts/concepts-26572ad.md
+++ b/docs/20---Concepts/concepts-26572ad.md
@@ -166,7 +166,9 @@ You can use the service with multitenant applications developed in the context o
 </b></dt>
 <dd>
 
-The service has to be bound to the calling application in the same Cloud Foundry Space. Otherwise or when calling public APIs, an invalid authorization header (JWT token) will be sent which can lead to technical problems (e.g. for CAP applications).
+You have to bind the Job Scheduling service instance to the application in the same Cloud Foundry space. When the service calls an endpoint, the request always contains the Authorization header (JWT token). To validate this token, make sure that your application is bound to the Job Scheduling service instance.
+
+For more information, see [Binding Service Instances to Applications](https://help.sap.com/docs/btp/sap-business-technology-platform/binding-service-instances-to-applications?version=Cloud).
 
 </dd>
 </dl>

--- a/docs/20---Concepts/concepts-26572ad.md
+++ b/docs/20---Concepts/concepts-26572ad.md
@@ -161,6 +161,16 @@ You can use the service with multitenant applications developed in the context o
 </dd>
 </dl>
 
+**Security**
+
+</b></dt>
+<dd>
+
+The service has to be bound to the calling application in the same Cloud Foundry Space. Otherwise or when calling public APIs, an invalid authorization header (JWT token) will be sent which can lead to technical problems (e.g. for CAP applications).
+
+</dd>
+</dl>
+
 **Related Information**  
 
 


### PR DESCRIPTION
Documented security constraints of Scheduler Service.

There was a big discussion on this limitation with BTP Scheduler Team, CAP Team and expert from XSSEC library on a SAP OSS Ticket.

Customers of BTP Scheduler Service should be aware of this limitation, as it is currently not mentioned in the documentation.

If you have any questions, Alexandar was working on the SAP OSS Ticket Case 472642/2024 "Calls for Public CAP-API using BTP Scheduler not working"

Best regards,
Ben

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

