### PR TITLE
Fix REUSE.toml

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-ersion = 1
+version = 1
 SPDX-PackageName = "btp-job-scheduling-service"
 SPDX-PackageSupplier = "Hördt Sylvia (sylvia.hoerdt@sap.com)"
 SPDX-PackageDownloadLocation = "https://github.com/SAP-docs/btp-job-scheduling-service"


### PR DESCRIPTION
The proper attribute should be `version`. It was changed to `ersion` 4 months ago https://github.com/SAP-docs/btp-job-scheduling-service/commit/1019e2b4700c7e34bdfdfe5de93aceddb5ce9fd8

Full error message:
```

  "badge": "https://api.reuse.software/badge/github.com/SAP-docs/btp-job-scheduling-service",
  "hash": "ed1003d229af6ee0849ae8088758373a3c301fa9",
  "last_access": "2025-07-24T23:53:24.212758+00:00",
  "lint_code": 2,
  "lint_output": "Usage: reuse lint [OPTIONS]\nTry 'reuse lint --help' for help.\n\nError: 'REUSE.toml' could not be parsed. We received the following error message: 'version' must be a 'int' (got None that is a \u003Cclass 'NoneType'\u003E).\nUsage: reuse spdx [OPTIONS]\nTry 'reuse spdx --help' for help.\n\nError: 'REUSE.toml' could not be parsed. We received the following error message: 'version' must be a 'int' (got None that is a \u003Cclass 'NoneType'\u003E).\n",
  "spdx_output": "\n",
  "status": "non-compliant",
  "url": "github.com/SAP-docs/btp-job-scheduling-service"
}
```
